### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action/action.php
+++ b/action/action.php
@@ -7,7 +7,7 @@ class action_plugin_components_action extends DokuWiki_Action_Plugin
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE', $this,
                                    'act');
     }

--- a/action/ajax.php
+++ b/action/ajax.php
@@ -13,7 +13,7 @@ class action_plugin_components_ajax extends DokuWiki_Action_Plugin {
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this,
                                    'call');
     }

--- a/action/render.php
+++ b/action/render.php
@@ -9,7 +9,7 @@ class action_plugin_components_render extends DokuWiki_Action_Plugin
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_ACT_RENDER', 'BEFORE', $this,
                                    'render');
     }

--- a/syntax/slice.php
+++ b/syntax/slice.php
@@ -37,7 +37,7 @@ class syntax_plugin_components_slice extends DokuWiki_Syntax_Plugin {
     /**
      * Handle the match
      */
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         switch ($state) {
             case DOKU_LEXER_SPECIAL:
                 $attr = $this->parse($match);
@@ -53,7 +53,7 @@ class syntax_plugin_components_slice extends DokuWiki_Syntax_Plugin {
     /**
      * Create output
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         if (!$data || $mode != 'xhtml') return;
         $id = $data['id'];
         $from = $data['from'];


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
